### PR TITLE
#2 - Pass context into ajax request

### DIFF
--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -3,6 +3,7 @@
 namespace HM\AdminBar;
 
 use WP_Admin_Bar;
+use WP_Screen;
 
 /**
  * Register the ajax endpoint for the remote admin bar.
@@ -16,9 +17,15 @@ function bootstrap() {
  *
  */
 function admin_bar_render() {
-	global $wp, $wp_admin_bar;
-	$wp->parse_request();
+	global $wp, $wp_admin_bar, $current_screen;
 
+	// Initialize query based on query string variables.
+	$wp->main( $_SERVER['QUERY_STRING'] ?? '' );
+
+	// Ensure that is_admin() returns false to register the correct menu nodes.
+	$current_screen = WP_Screen::get( 'front' );
+
+	// Set up the admin bar for the current view.
 	require_once ABSPATH . WPINC . '/class-wp-admin-bar.php';
 
 	$wp_admin_bar = new WP_Admin_Bar();

--- a/src/index.js
+++ b/src/index.js
@@ -6,8 +6,9 @@
  * @return {Promise} Promise, which when fulfilled, resolves with markup, scripts, and styles.
  */
 const getAdminBar = async ( siteurl, context ) => {
+	const ajaxParams = new URLSearchParams( { ...context, action: 'admin_bar_render' } );
 	const response = await fetch(
-		`${siteurl}/wp-admin/admin-ajax.php?action=admin_bar_render`,
+		`${siteurl}/wp-admin/admin-ajax.php?${ajaxParams}`,
 		{ credentials: 'include' }
 	);
 


### PR DESCRIPTION
This updates the API of the client-side `getAdminBar()` function so that the current viewing context can be passed in using any public query vars registered in WordPress, and ensures that the admin bar returned is contextually appropriate for a front-end request with the currently queried object.

On the client-side, this means you can make calls like:

```
// No "Edit" menu.
getAdminBar( 'http://local.dev', { p: 702926 }).then( render ); 

 // Will include an "Edit post" for post ID 702926.
getAdminBar( 'http://local.dev', { p: 702926 }).then( render );

// Will include an "Edit category" link for Sports.
getAdminBar( 'http://local.dev.', { category_name: 'sports' }).then( render ); 
```

Fixes #2.

