### PR TITLE
#4 - Add `npm publish` script as GitHub Action

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,11 +16,8 @@ jobs:
           node-version: 12
           registry-url: https://registry.npmjs.org/
 
-      - run: npm install && npm run build
+      - run: npm ci && npm run build
 
-      - id: publish
-        uses: JS-DevTools/npm-publish@v1
-        with:
-          access: public
-          tag:
-          token: ${{ secrets.NPM_TOKEN }}
+      - run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,7 +24,3 @@ jobs:
         uses: JS-DevTools/npm-publish@v1
         with:
           token: ${{ secrets.NPM_TOKEN }}
-
-     - if: steps.publish.outputs.type != 'none'
-        run: |
-          echo "Version changed: ${{ steps.publish.outputs.old-version }} => ${{ steps.publish.outputs.version }}"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,7 +20,8 @@ jobs:
 
       - run: npm run build
 
-      - uses: JS-DevTools/npm-publish@v1
+      - id: publish
+        uses: JS-DevTools/npm-publish@v1
         with:
           token: ${{ secrets.NPM_TOKEN }}
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,11 +16,11 @@ jobs:
           node-version: 12
           registry-url: https://registry.npmjs.org/
 
-      - run: npm install
-
-      - run: npm run build
+      - run: npm install && npm run build
 
       - id: publish
         uses: JS-DevTools/npm-publish@v1
         with:
+          access: public
+          tag:
           token: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,29 @@
+name: Publish to npm
+
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  npm-publish-new-release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 12
+          registry-url: https://registry.npmjs.org/
+
+      - run: npm install
+
+      - run: npm run build
+
+      - uses: JS-DevTools/npm-publish@v1
+        with:
+          token: ${{ secrets.NPM_TOKEN }}
+
+     - if: steps.publish.outputs.type != 'none'
+        run: |
+          echo "Version changed: ${{ steps.publish.outputs.old-version }} => ${{ steps.publish.outputs.version }}"

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <table width="100%">
 	<tr>
 		<td align="left" width="80%">
-			<h1>Remote Admin Bar</h1> 
+			<h1>Remote Admin Bar</h1>
       Enables the WordPress admin bar for use on headless or decoupled sites
 		</td>
 		<td rowspan="2" width="20%">
@@ -15,6 +15,29 @@
 	</tr>
 </table>
 
+## How to use this plugin
+
+Install the plugin in the WordPress project and activate it like any other plugin.
+
+On the client side, require the client side scripts by running
+
+```
+npm install @humanmade/remote-admin-bar --save-dev
+```
+
+In your client-side app, there are three basic functions exposed, `getAdminBar()`, which returns a promise that resolves with data required to render the admin bar, and `render()` and `refresh()`, which can be called with the resolution of this promise and either render it to the page or refresh an admin bar which has already been rendered on a SPA with updated contents based on the new route.
+
+The getAdminBar function takes two arguments, the site URL of the site to query and an object containing context about the current view. This context argument is parsed just like public query variables in WordPress, so any parameter that can be passed through a URL query string will work here.
+
+As an example, the following request will render an admin bar containing an edit link for post ID 1234:
+
+```
+import { getAdminBar, render } from '@humanmade/remote-admin-bar';
+
+getAdminBar( 'https://yoursite.dev', { p: 1234 } ).then( render );
+
+```
+
 ## Development Process
 
 The development process follows [the standard Human Made development process](http://engineering.hmn.md/how-we-work/process/development/).
@@ -26,3 +49,11 @@ Here's a quick summary:
 * File a PR early so it can be used for tracking progress.
 * When you're finished, mark the PR for review by labelling with "Review &amp; Merge".
 * Get someone to review your code, and assign to them; if no one is around, the project lead () can review.
+
+## Cutting a new release
+
+The process of releasing a new version of this plugin is as follows:
+
+- Update the version numbers in `package.json` and `plugin.php`.
+- Add an entry to the CHANGELOG describing the changes.
+- Once the PR is merged, push a new tag to this repository. This will trigger a new package version to be pushed to npm.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "remote-admin-bar",
+  "name": "@humanmade/remote-admin-bar",
   "version": "0.0.1",
   "lockfileVersion": 1,
   "requires": true,

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
-  "name": "remote-admin-bar",
+  "name": "@humanmade/remote-admin-bar",
+  "public": true,
   "version": "0.0.1",
   "description": "Enables the WordPress admin bar for use on headless or decoupled sites .",
   "main": "dist/index.js",
@@ -12,7 +13,7 @@
     "type": "git",
     "url": "git+https://github.com/humanmade/remote-admin-bar.git"
   },
-  "author": "",
+  "author": "Human Made",
   "license": "GPL-3.0-or-later",
   "bugs": {
     "url": "https://github.com/humanmade/remote-admin-bar/issues"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@humanmade/remote-admin-bar",
   "public": true,
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Enables the WordPress admin bar for use on headless or decoupled sites .",
   "main": "dist/index.js",
   "scripts": {

--- a/plugin.php
+++ b/plugin.php
@@ -4,7 +4,7 @@ Plugin Name: Remote Admin Bar
 Description: Serves the WordPress admin bar remotely for use in headless or decoupled sites.
 Author: Human Made
 Author URI: http://humanmade.com
-Version: 0.1
+Version: 0.0.1
 License: GPL 2+
 */
 

--- a/plugin.php
+++ b/plugin.php
@@ -4,7 +4,7 @@ Plugin Name: Remote Admin Bar
 Description: Serves the WordPress admin bar remotely for use in headless or decoupled sites.
 Author: Human Made
 Author URI: http://humanmade.com
-Version: 0.0.1
+Version: 0.0.2
 License: GPL 2+
 */
 


### PR DESCRIPTION
Adds a GitHub workflow which publishes a new version of the build client side scripts as an npm package every time a new tag is pushed to this repository. Updates README with basic usage examples and instructions for cutting a new version.

Fixes #4.
