### PR TITLE
#5 - Set a client-side cookie for tracking logged-in state

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,10 @@
 	</tr>
 </table>
 
+## Requirements
+
+Requires PHP >= 7.3.
+
 ## How to use this plugin
 
 Install the plugin in the WordPress project and activate it like any other plugin.

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -9,8 +9,12 @@ use WP_Screen;
  * Register the ajax endpoint for the remote admin bar.
  */
 function bootstrap() {
+
+	// Make sure cookie constants are defined when needed.
+	wp_cookie_constants();
+
 	add_action( 'wp_ajax_admin_bar_render', __NAMESPACE__ . '\\admin_bar_render' );
-	add_action( 'wp_login', __NAMESPACE__ . '\\set_js_cookie' );
+	add_action( 'wp_login', __NAMESPACE__ . '\\set_js_cookie', 10, 4 );
 	add_action( 'wp_logout', __NAMESPACE__ . '\\clear_js_cookie' );
 }
 
@@ -63,9 +67,9 @@ function set_js_cookie( $user_id, $user ) {
 		'wp_remote_admin_bar',
 		1,
 		[
-			'domain'   => COOKIEDOMAIN,
+			'domain'   => COOKIE_DOMAIN,
 			'expires'  => $expires,
-			'path'     => SITE_COOKIE_PATH,
+			'path'     => COOKIEPATH,
 			'httponly' => false
 		] );
 }
@@ -78,9 +82,9 @@ function clear_js_cookie() {
 		'wp_remote_admin_bar',
 		0,
 		[
-			'domain'  => COOKIEDOMAIN,
+			'domain'  => COOKIE_DOMAIN,
 			'expires' => time() - YEAR_IN_SECONDS,
-			'path'    => SITE_COOKIE_PATH,
+			'path'    => COOKIEPATH,
 		]
 	);
 }

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -61,7 +61,7 @@ function set_js_cookie( $user_id, $user ) {
 	/**
 	 * Set the expiration time of the logged-in cookie to the same time as a user auth cookie.
 	 */
-	$expiration = time() + apply_filters( 'auth_cookie_expiration', 14 * DAY_IN_SECONDS, $user->user_id, false );
+	$expiration = time() + apply_filters( 'auth_cookie_expiration', 14 * DAY_IN_SECONDS, $user->user_id, true );
 
 	setcookie(
 		'wp_remote_admin_bar',

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -16,7 +16,6 @@ function bootstrap() {
 
 /**
  * Return the HTML, scripts, and styles for the remote admin bar.
- *
  */
 function admin_bar_render() {
 	global $wp, $wp_admin_bar, $current_screen;
@@ -49,13 +48,23 @@ function admin_bar_render() {
  * Set a cookie to identify that the current user is logged in.
  *
  * We can't rely on WordPress's LOGGED_IN_COOKIE, which is HTTP-only.
+ *
+ * @param string  $user_login Username of current user.
+ * @param WP_User $user       Current user object.
  */
-function set_js_cookie() {
+function set_js_cookie( $user_id, $user ) {
+
+	/**
+	 * Set the expiration time of the logged-in cookie to the same time as a user auth cookie.
+	 */
+	$expiration = time() + apply_filters( 'auth_cookie_expiration', 14 * DAY_IN_SECONDS, $user->user_id, false );
+
 	setcookie(
 		'wp_remote_admin_bar',
 		1,
 		[
 			'domain'   => COOKIEDOMAIN,
+			'expires'  => $expires,
 			'path'     => SITE_COOKIE_PATH,
 			'httponly' => false
 		] );
@@ -70,8 +79,8 @@ function clear_js_cookie() {
 		0,
 		[
 			'domain'  => COOKIEDOMAIN,
-			'path'    => SITE_COOKIE_PATH,
 			'expires' => time() - YEAR_IN_SECONDS,
+			'path'    => SITE_COOKIE_PATH,
 		]
 	);
 }

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -10,6 +10,8 @@ use WP_Screen;
  */
 function bootstrap() {
 	add_action( 'wp_ajax_admin_bar_render', __NAMESPACE__ . '\\admin_bar_render' );
+	add_action( 'wp_login', __NAMESPACE__ . '\\set_js_cookie' );
+	add_action( 'wp_logout', __NAMESPACE__ . '\\clear_js_cookie' );
 }
 
 /**
@@ -41,6 +43,37 @@ function admin_bar_render() {
 	rest_send_cors_headers( true );
 	wp_send_json( $admin_bar_data );
 	die();
+}
+
+/**
+ * Set a cookie to identify that the current user is logged in.
+ *
+ * We can't rely on WordPress's LOGGED_IN_COOKIE, which is HTTP-only.
+ */
+function set_js_cookie() {
+	setcookie(
+		'wp_remote_admin_bar',
+		1,
+		[
+			'domain'   => COOKIEDOMAIN,
+			'path'     => SITE_COOKIE_PATH,
+			'httponly' => false
+		] );
+}
+
+/**
+ * Clear the cookie used to identify logged in users.
+ */
+function clear_js_cookie() {
+	setcookie(
+		'wp_remote_admin_bar',
+		0,
+		[
+			'domain'  => COOKIEDOMAIN,
+			'path'    => SITE_COOKIE_PATH,
+			'expires' => time() - YEAR_IN_SECONDS,
+		]
+	);
 }
 
 /**

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -69,8 +69,8 @@ function set_js_cookie( $user_id, $user ) {
 		[
 			'domain'   => COOKIE_DOMAIN,
 			'expires'  => $expires,
+			'httponly' => false,
 			'path'     => COOKIEPATH,
-			'httponly' => false
 		] );
 }
 

--- a/plugin.php
+++ b/plugin.php
@@ -4,6 +4,7 @@ Plugin Name: Remote Admin Bar
 Description: Serves the WordPress admin bar remotely for use in headless or decoupled sites.
 Author: Human Made
 Author URI: http://humanmade.com
+Requires PHP: 7.3
 Version: 0.0.2
 License: GPL 2+
 */

--- a/src/index.js
+++ b/src/index.js
@@ -54,3 +54,10 @@ const refresh = adminBarData => {
 		adminBar.outerHTML = adminBarData.markup;
 	}
 };
+
+export {
+  isLoggedIn,
+  getAdminBar,
+  render,
+  refresh,
+};

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,15 @@
 /**
+ * Check if the current user has the wp_remote_admin_bar cookie set.
+ *
+ * On sites where the front end is served from the same domain and path as the
+ * admin, this function can be used so that non-logged in users don't trigger
+ * origin requests to the admin-ajax endpoint.
+ *
+ * @return {Boolean} Whether the current user appears to be logged into the admin.
+ */
+const isLoggedIn = () => document.cookie.match( /^(.*;)?\s*wp_remote_admin_bar\s*=\s*[^;]+(.*)?$/ );
+
+/**
  * Retrieve the admin bar data for the current context.
  *
  * @param {string} siteurl Root URL for the current site.


### PR DESCRIPTION
Prevents making extra Ajax requests by setting a cookie which can be checked in JS before making an admin-ajax request to get the admin bar.

Fixes #5.