### PR TITLE
#6 - Add hook for removing menu items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+
+## 0.0.4
+- Add 'remote_admin_bar_menu' hook which can be used to add or remove menu nodes specifically in the remote context.
+
+## 0.0.3
+- Set cookie on login which is not http-only, so that the client side library can do an intitial check of the user's logged in state before making admin-ajax requests.
+- Add `isLoggedIn` function to the client package which checks for the presense of this cookie.
+
+## 0.0.2
+- Properly set context of the admin bar based on any public query cars in the request.
+- Add action to publish npm package versions when a new tag is pushed to this repo.
+
+## 0.0.1
+- Initial commits and proof of concept.

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -106,6 +106,15 @@ function get_markup() {
 	do_action_ref_array( 'admin_bar_menu', [ &$wp_admin_bar ] );
 
 	/**
+	 * Hook for ease of targeting admin menu nodes only when serving admin bar remotely.
+	 *
+	 * Use this to remove entries which don't make sense on headless sites, for example.
+	 *
+	 * @param WP_Admin_Bar GLobal admin bar object (passed by reference).
+	 */
+	do_action_ref_array( 'remote_admin_bar_menu', [ &$wp_admin_bar ] );
+
+	/**
 	 * Core hook for adding output before the admin bar is rendered.
 	 */
 	do_action( 'wp_before_admin_bar_render' );

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@humanmade/remote-admin-bar",
   "public": true,
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "Enables the WordPress admin bar for use on headless or decoupled sites .",
   "main": "dist/index.js",
   "scripts": {

--- a/plugin.php
+++ b/plugin.php
@@ -5,7 +5,7 @@ Description: Serves the WordPress admin bar remotely for use in headless or deco
 Author: Human Made
 Author URI: http://humanmade.com
 Requires PHP: 7.3
-Version: 0.0.3
+Version: 0.0.4
 License: GPL 2+
 */
 


### PR DESCRIPTION
Adds the 'remote_admin_bar_menu' hook, which fires after setting up the admin bar and can be used to remove items that don't make sense to show in a headless context (Query Monitor was the initial impetus here, but any nodes can be removed as needed.)

Fixes #6.