### PR TITLE
Fix es2015 compatability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.0.5
+- Remove usage of es-next syntax which was not transpiled to JS which worked in environments without regenerator runtime.
+
 ## 0.0.4
 - Add 'remote_admin_bar_menu' hook which can be used to add or remove menu nodes specifically in the remote context.
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@humanmade/remote-admin-bar",
   "public": true,
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "Enables the WordPress admin bar for use on headless or decoupled sites .",
   "main": "dist/index.js",
   "scripts": {

--- a/plugin.php
+++ b/plugin.php
@@ -5,7 +5,7 @@ Description: Serves the WordPress admin bar remotely for use in headless or deco
 Author: Human Made
 Author URI: http://humanmade.com
 Requires PHP: 7.3
-Version: 0.0.4
+Version: 0.0.5
 License: GPL 2+
 */
 

--- a/src/index.js
+++ b/src/index.js
@@ -16,14 +16,12 @@ const isLoggedIn = () => document.cookie.match( /^(.*;)?\s*wp_remote_admin_bar\s
  * @param {object} context Current browsing context.
  * @return {Promise} Promise, which when fulfilled, resolves with markup, scripts, and styles.
  */
-const getAdminBar = async ( siteurl, context ) => {
+const getAdminBar = ( siteurl, context ) => {
 	const ajaxParams = new URLSearchParams( { ...context, action: 'admin_bar_render' } );
-	const response = await fetch(
+	return fetch(
 		`${siteurl}/wp-admin/admin-ajax.php?${ajaxParams}`,
 		{ credentials: 'include' }
-	);
-
-	return response.json();
+	).then( response => response.json() );
 };
 
 /**


### PR DESCRIPTION
The async/await syntax in this module caused issues in environments without support for generators. While it's possible to fix this by changing the babel target in this repo, it's just as easy, and probably easier to read, to just return a promise rather than an awaited result - the end use is the same in either case.

This fixes an issue where running tests in another project would give the error

```
  ● Test suite failed to run

    ReferenceError: regeneratorRuntime is not defined
```