### PR TITLE
Revert "Fix es2015 compatability"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,5 @@
 # Changelog
 
-## 0.0.5
-- Remove usage of es-next syntax which was not transpiled to JS which worked in environments without regenerator runtime.
-
 ## 0.0.4
 - Add 'remote_admin_bar_menu' hook which can be used to add or remove menu nodes specifically in the remote context.
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@humanmade/remote-admin-bar",
   "public": true,
-  "version": "0.0.5",
+  "version": "0.0.4",
   "description": "Enables the WordPress admin bar for use on headless or decoupled sites .",
   "main": "dist/index.js",
   "scripts": {

--- a/plugin.php
+++ b/plugin.php
@@ -5,7 +5,7 @@ Description: Serves the WordPress admin bar remotely for use in headless or deco
 Author: Human Made
 Author URI: http://humanmade.com
 Requires PHP: 7.3
-Version: 0.0.5
+Version: 0.0.4
 License: GPL 2+
 */
 

--- a/src/index.js
+++ b/src/index.js
@@ -16,12 +16,14 @@ const isLoggedIn = () => document.cookie.match( /^(.*;)?\s*wp_remote_admin_bar\s
  * @param {object} context Current browsing context.
  * @return {Promise} Promise, which when fulfilled, resolves with markup, scripts, and styles.
  */
-const getAdminBar = ( siteurl, context ) => {
+const getAdminBar = async ( siteurl, context ) => {
 	const ajaxParams = new URLSearchParams( { ...context, action: 'admin_bar_render' } );
-	return fetch(
+	const response = await fetch(
 		`${siteurl}/wp-admin/admin-ajax.php?${ajaxParams}`,
 		{ credentials: 'include' }
-	).then( response => response.json() );
+	);
+
+	return response.json();
 };
 
 /**


### PR DESCRIPTION
Reverts humanmade/remote-admin-bar#13 - this wasn't necessary, and it's reasonable to expect libraries to just include a regenerator runtime in order to use this in tests.