### PR TITLE
Send CORS headers in response to preflight request

### DIFF
--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -68,7 +68,6 @@ function admin_bar_render() {
 		'styles' => get_styles(),
 	];
 
-	rest_send_cors_headers( true );
 	wp_send_json( $admin_bar_data );
 	die();
 }

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -13,9 +13,24 @@ function bootstrap() {
 	// Make sure cookie constants are defined when needed.
 	wp_cookie_constants();
 
+	add_action( 'wp_ajax_nopriv_admin_bar_render', __NAMESPACE__ . '\\send_cors_preflight_headers' );
 	add_action( 'wp_ajax_admin_bar_render', __NAMESPACE__ . '\\admin_bar_render' );
 	add_action( 'wp_login', __NAMESPACE__ . '\\set_js_cookie', 10, 4 );
 	add_action( 'wp_logout', __NAMESPACE__ . '\\clear_js_cookie' );
+}
+
+/**
+ * Send proper CORS headers in response to unauthorized OPTIONS request.
+ *
+ * This is necessary to satisfy the CORS preflight request some browsers
+ * perform before sending credentials.
+ */
+function send_cors_preflight_headers() {
+	if ( $_SERVER['REQUEST_METHOD'] === 'OPTIONS' ) {
+		rest_send_cors_headers();
+	}
+
+	die(0);
 }
 
 /**

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -34,9 +34,7 @@ function allow_cross_origin_admin_bar_requests( $allowed_origin, $origin ) {
 		return $allowed_origin;
 	}
 
-	$ajax_action = $_GET['action'] ?? '';
-
-	if ( $ajax_action === 'admin_bar_render' ) {
+	if ( ! empty( $_GET['action'] ) && $_GET['action'] === 'admin_bar_render' ) {
 		$allowed_origin = $origin;
 	}
 


### PR DESCRIPTION
Some browsers, such as Chrome, now send an unauthenticated OPTIONS request to an XHR endpoint before sending credentials. If the admin-ajax endpoint doesn't send the proper header in response to this preflight request, the credentials will never be sent.

In practice, this meant that users in Chrome were not seeing the admin bar in cases where they should have been.