### PR TITLE
Revert "Remove async/await syntax for ES2015 compatability"

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -16,12 +16,14 @@ const isLoggedIn = () => document.cookie.match( /^(.*;)?\s*wp_remote_admin_bar\s
  * @param {object} context Current browsing context.
  * @return {Promise} Promise, which when fulfilled, resolves with markup, scripts, and styles.
  */
-const getAdminBar = ( siteurl, context ) => {
+const getAdminBar = async ( siteurl, context ) => {
 	const ajaxParams = new URLSearchParams( { ...context, action: 'admin_bar_render' } );
-	return fetch(
+	const response = await fetch(
 		`${siteurl}/wp-admin/admin-ajax.php?${ajaxParams}`,
 		{ credentials: 'include' }
-	).then( response => response.json() );
+	);
+
+	return response.json();
 };
 
 /**


### PR DESCRIPTION
This reverts commit 011890f32650f7731a79e00bd291f68ac11e153d.

Re-adds async/await syntax, which is more familiar than promises. I'm happy to transpile the module into promises if needed, but this change wasn't needed.