### PR TITLE
Fix typo

### DIFF
--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -90,7 +90,7 @@ function set_js_cookie( $user_id, $user ) {
 		1,
 		[
 			'domain'   => COOKIE_DOMAIN,
-			'expires'  => $expires,
+			'expires'  => $expiration,
 			'httponly' => false,
 			'path'     => COOKIEPATH,
 		] );


### PR DESCRIPTION
Currently this throws an undefined variable warning; this fix should resolve that.